### PR TITLE
Revise self-hosting step from "at first" to "first".

### DIFF
--- a/frontend/src/routes/docs/self-host/+page.svelte
+++ b/frontend/src/routes/docs/self-host/+page.svelte
@@ -63,7 +63,7 @@ SPDX-License-Identifier: MPL-2.0
 	</ul>
 
 	<h2>Installation</h2>
-	<p>At first, clone the repo:</p>
+	<p>First, clone the repo:</p>
 
 	<pre><code class="language-bash"
 			>git clone https://github.com/mawoka-myblock/classquiz && cd ClassQuiz</code


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Marlon W (Mawoka)

SPDX-License-Identifier: MPL-2.0
-->
In the documentation for installing ClassQuiz as self-hosted software, the user is told, "At first, clone the repo:". This is an incorrect use of the phrase "at first", and although most would likely understand it regardless, it would be a good idea to replace it with the more correct "First".

#### Testing
Based on the trivial nature of the pull request (changing the contents of a p tag), I would say minimal testing is needed.

![image](https://github.com/mawoka-myblock/ClassQuiz/assets/79549730/019f5e57-9d61-40d2-8a63-fb6da52ea506)
An example screenshot of what it would look like.