### PR TITLE
:sparkles: backend : make Settings configurable

### DIFF
--- a/classquiz/config.py
+++ b/classquiz/config.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import re
+import os
 from functools import lru_cache
 
 from redis import asyncio as redis_lib
@@ -28,22 +29,22 @@ class Settings(BaseSettings):
     Settings class for the shop app.
     """
 
-    root_address: str = "http://127.0.0.1:8000"
-    redis: RedisDsn = "redis://localhost:6379/0?decode_responses=True"
-    skip_email_verification: bool = False
-    db_url: str | PostgresDsn = "postgresql://postgres:mysecretpassword@localhost:5432/classquiz"
+    root_address: str = os.getenv("ROOT_ADDRESS", "http://127.0.0.1:8000")
+    redis: RedisDsn = os.getenv("REDIS_URL", "redis://localhost:6379/0?decode_responses=True")
+    skip_email_verification: bool = os.getenv("SKIP_EMAIL_VERIFICATION", "False") == 'True'
+    db_url: str | PostgresDsn = os.getenv("DB_URL", "postgresql://postgres:mysecretpassword@localhost:5432/classquiz")
     hcaptcha_key: str | None = None
     recaptcha_key: str | None = None
-    mail_address: str
-    mail_password: str
-    mail_username: str
-    mail_server: str
-    mail_port: int
-    secret_key: str
+    mail_address: str = os.getenv("MAIL_ADDRESS", None)
+    mail_password: str = os.getenv("MAIL_PASSWORD", None)
+    mail_username: str = os.getenv("MAIL_USERNAME", None)
+    mail_server: str = os.getenv("MAIL_SERVER", None)
+    mail_port: int = os.getenv("MAIL_PORT", None)
+    secret_key: str = os.getenv("SECRET_KEY", None)
     access_token_expire_minutes: int = 30
     cache_expiry: int = 86400
     sentry_dsn: str | None
-    meilisearch_url: str = "http://127.0.0.1:7700"
+    meilisearch_url: str = os.getenv("MEILISEARCH_URL", "http://127.0.0.1:7700")
     meilisearch_index: str = "classquiz"
     google_client_id: Optional[str]
     google_client_secret: Optional[str]
@@ -57,10 +58,10 @@ class Settings(BaseSettings):
     registration_disabled: bool = False
 
     # storage_backend
-    storage_backend: str | None = "local"
+    storage_backend: str = os.getenv("STORAGE_BACKEND", "local")
 
     # if storage_backend == "local":
-    storage_path: str | None
+    storage_path: str = os.getenv("STORAGE_PATH", None)
 
     # if storage_backend == "s3":
     s3_access_key: str | None


### PR DESCRIPTION
Most common Settings can be set by environment variables.

<!--
SPDX-FileCopyrightText: 2023 Marlon W (Mawoka)

SPDX-License-Identifier: MPL-2.0
-->

#### :tophat: What? Why?
We could not configure the app as we liked.

Therefore we extended the backend/api to read important Settings from environment variables.

#### :pushpin: Related Issues

#### Testing

We are testing it by running docker compose.
What we do not understand, is why there are env var settings in the docker-compose.yml that should already configure the settings right.

#### :clipboard: Checklist
⚠️  No tests suites for now ⚠️
:rotating_light: Please review the [guidelines for contributing](https://github.com/mawoka-myblock/ClassQuiz/blob/master/CONTRIBUTING.md) to this repository.

- [ ] :question: ~~**CONSIDER** adding a unit test if your PR resolves an issue.~~
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: ~~**DO** make sure tests pass.~~
  - was not able to execute the run_tests.sh script
- [ ] :heavy_check_mark: ~~**DO** add CHANGELOG upgrade notes if required.~~
- [ ] :x:~~**AVOID** breaking the continuous integration build.~~
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots


:hearts: Thank you!
