### PR TITLE
👷 Added more strict conditions on linting job

### DIFF
--- a/.github/workflows/frontend_lint.yml
+++ b/.github/workflows/frontend_lint.yml
@@ -11,9 +11,13 @@ on:
   push:
     branches: [ master ]
     paths:
-      - "frontend/**"
+      - "frontend/**/*.{ts,js,svelte}"
+      - ".github/workflows/frontend_lint.yml"
   workflow_dispatch:
   pull_request:
+    paths:
+      - "frontend/**/*.{ts,js,svelte}"
+      - ".github/workflows/frontend_lint.yml"
 
 jobs:
   frontend_lint:


### PR DESCRIPTION
#### :tophat: What? Why?
This PR aims to optimize linting job in CI.

Because of the previous conditions frontend linting CI was running all the time, this isn't a good practice nor very compute-friendly.
Due to the linting upgrade from #527 it should be better to only run this when files that are checked are modified.

We also want to run this when the CI file is modified just to be sure.
These changes should be checked first, than if useful could be added to other CI files too 👍

(This is only for maintainers and contributors experience)

#### :pushpin: Related Issues
No issue related

#### Testing
Modify a frontend file, commit, create PR and check if CI runs
Modify a file not impacted by linting, commit, create PR and check if CI doesn't run for linting

#### :clipboard: Checklist
⚠️  No tests suites for now ⚠️
:rotating_light: Please review the [guidelines for contributing](https://github.com/mawoka-myblock/ClassQuiz/blob/master/CONTRIBUTING.md) to this repository.

- [ ] :question: ~~**CONSIDER** adding a unit test if your PR resolves an issue.~~
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: ~~**DO** make sure tests pass.~~
- [ ] :heavy_check_mark: ~~**DO** add CHANGELOG upgrade notes if required.~~
- [ ] :x:~~**AVOID** breaking the continuous integration build.~~
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
Not relevant

:hearts: Your time is precious, thank you for giving it to me !
