### PR TITLE
fix: Validate that player question_index input is the current question

### DIFF
--- a/classquiz/socket_server/__init__.py
+++ b/classquiz/socket_server/__init__.py
@@ -292,10 +292,16 @@ async def submit_answer(sid: str, data: dict):
     session = await get_session(sid, sio)
     question_index = int(float(data.question_index))
     game_data = await PlayGame.get_from_redis(session["game_pin"])
+
+    if game_data.current_question != question_index:
+        await sio.emit("question_not_active", room=sid)
+        return
+
     already_answered = await has_already_answered(session["game_pin"], question_index, session["username"])
     if already_answered:
         await sio.emit("already_replied", room=sid)
         return
+
     answer_right, answer = check_answer(game_data, data)
     latency = int(float(session["ping"]))
     time_q_started = datetime.fromisoformat(await redis.get(f"game:{session['game_pin']}:current_time"))

--- a/classquiz/socket_server/__init__.py
+++ b/classquiz/socket_server/__init__.py
@@ -293,7 +293,7 @@ async def submit_answer(sid: str, data: dict):
     question_index = int(float(data.question_index))
     game_data = await PlayGame.get_from_redis(session["game_pin"])
 
-    if game_data.current_question != question_index:
+    if question_index != game_data.current_question:
         await sio.emit("question_not_active", room=sid)
         return
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Marlon W (Mawoka)

SPDX-License-Identifier: MPL-2.0
-->

#### :tophat: What? Why?
This PR validates the `question_index` input sent by players in `submit_answer()`. Previously, this input could be manipulated by malicious clients to send responses to future questions, or negative answers (as the answers are used as an index in a Python array, which accepts negative numbers). This would result in the host seeing more submitted answers that there were players in total

#### Testing
Make a malicious client (e.g. Burpsuite) send requests such as `42["submit_answer",{"question_index":-1,"answer":"A"}]` through the websocket

#### :clipboard: Checklist
⚠️  No tests suites for now ⚠️
:rotating_light: Please review the [guidelines for contributing](https://github.com/mawoka-myblock/ClassQuiz/blob/master/CONTRIBUTING.md) to this repository.

- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [x] :heavy_check_mark: ~~**DO** make sure tests pass.~~
- [ ] :heavy_check_mark: ~~**DO** add CHANGELOG upgrade notes if required.~~
- [x] :x:~~**AVOID** breaking the continuous integration build.~~
- [x] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

:hearts: Thank you!
