### PR TITLE
✨ Created way to declare runtime-defined env vars

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -39,6 +39,8 @@ RUN pnpm run build
 # pull the Node.js Docker image
 FROM node:24-trixie-slim
 
+RUN apt update && apt install -y gettext
+
 # change working directory
 WORKDIR /app
 COPY --from=builder /usr/src/app/package.json .
@@ -52,4 +54,4 @@ COPY --from=builder /usr/src/app/node_modules ./node_modules
 EXPOSE 3000
 
 # the command that starts our app
-CMD ["pnpm", "run", "run:prod"]
+CMD ["/bin/sh", "-c", "envsubst < ./client/scripts/env.template.js > ./client/scripts/env.js && pnpm run run:prod"]

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -40,6 +40,7 @@ SPDX-License-Identifier: MPL-2.0
 		<meta name="application-name" content="ClassQuiz" />
 		<meta name="msapplication-TileColor" content="#00a300" />
 		<meta name="theme-color" content="#ffffff" />
+		<script src="%sveltekit.assets%/scripts/env.js"></script>
 		%sveltekit.head%
 	</head>
 	<body>

--- a/frontend/src/lib/runtime/env.ts
+++ b/frontend/src/lib/runtime/env.ts
@@ -2,12 +2,23 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+/**
+ * This wrapper allow to both, frontend and backend, to get env vars that are set at runtime in the Dockerfile.
+ * It will first try to get the env var from the window object, if it fails (which means we are in the backend), it will try to get it from process.env.
+ */
 export const runtimeEnvVarWrapper = {
-	get: function (name) {
-		try {
-			return window.env[name];
-		} catch (e) {
-			return process.env[name];
-		}
-	}
+
+    /**
+     * This function allow to get env vars that are set at runtime in the Dockerfile
+     * @param name Name of the env var we want
+     * @returns Value of the env var
+     */
+    get(name: string): string | undefined {
+        try {
+            return window.env[name];
+        }
+        catch (_) {
+            return process.env[name];
+        }
+    }
 };

--- a/frontend/src/lib/runtime/env.ts
+++ b/frontend/src/lib/runtime/env.ts
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Marlon W (Mawoka)
+//
+// SPDX-License-Identifier: MPL-2.0
+
+export const runtimeEnvVarWrapper = {
+    get: function (name) {
+        try {
+            return window.env[name];
+        }
+        catch (e) {
+            return process.env[name];
+        }
+    }
+};

--- a/frontend/src/lib/runtime/env.ts
+++ b/frontend/src/lib/runtime/env.ts
@@ -7,18 +7,16 @@
  * It will first try to get the env var from the window object, if it fails (which means we are in the backend), it will try to get it from process.env.
  */
 export const runtimeEnvVarWrapper = {
-
-    /**
-     * This function allow to get env vars that are set at runtime in the Dockerfile
-     * @param name Name of the env var we want
-     * @returns Value of the env var
-     */
-    get(name: string): string | undefined {
-        try {
-            return window.env[name];
-        }
-        catch (_) {
-            return process.env[name];
-        }
-    }
+	/**
+	 * This function allow to get env vars that are set at runtime in the Dockerfile
+	 * @param name Name of the env var we want
+	 * @returns Value of the env var
+	 */
+	get(name: string): string | undefined {
+		try {
+			return window.env[name];
+		} catch (_) {
+			return process.env[name];
+		}
+	}
 };

--- a/frontend/src/lib/runtime/env.ts
+++ b/frontend/src/lib/runtime/env.ts
@@ -3,12 +3,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 export const runtimeEnvVarWrapper = {
-    get: function (name) {
-        try {
-            return window.env[name];
-        }
-        catch (e) {
-            return process.env[name];
-        }
-    }
+	get: function (name) {
+		try {
+			return window.env[name];
+		} catch (e) {
+			return process.env[name];
+		}
+	}
 };

--- a/frontend/static/scripts/env.template.js
+++ b/frontend/static/scripts/env.template.js
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 (function (window) {
-  window.env = window.env || {};
+	window.env = window.env || {};
 
-  window['env']['TEST_VARIABLE'] = '${TEST_VARIABLE}';
+	window['env']['TEST_VARIABLE'] = '${TEST_VARIABLE}';
 })(this);

--- a/frontend/static/scripts/env.template.js
+++ b/frontend/static/scripts/env.template.js
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Marlon W (Mawoka)
+//
+// SPDX-License-Identifier: MPL-2.0
+
+(function (process) {
+  process.env = process.env || {};
+
+  process['env']['TEST_VARIABLE'] = '${TEST_VARIABLE}';
+})(this);

--- a/frontend/static/scripts/env.template.js
+++ b/frontend/static/scripts/env.template.js
@@ -2,8 +2,11 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+// This function is called in frontend
+// Each variable is replaced by envsubst in the Dockerfile, so that they can be set at runtime
+// The syntax should be ```window.env.VARIABLE_NAME = '${VARIABLE_NAME}';```
 (function (window) {
 	window.env = window.env || {};
 
-	window['env']['TEST_VARIABLE'] = '${TEST_VARIABLE}';
+  window.env.TEST_VARIABLE = '${TEST_VARIABLE}';
 })(this);

--- a/frontend/static/scripts/env.template.js
+++ b/frontend/static/scripts/env.template.js
@@ -8,5 +8,5 @@
 (function (window) {
 	window.env = window.env || {};
 
-  window.env.TEST_VARIABLE = '${TEST_VARIABLE}';
+	window.env.TEST_VARIABLE = '${TEST_VARIABLE}';
 })(this);

--- a/frontend/static/scripts/env.template.js
+++ b/frontend/static/scripts/env.template.js
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-(function (process) {
-  process.env = process.env || {};
+(function (window) {
+  window.env = window.env || {};
 
-  process['env']['TEST_VARIABLE'] = '${TEST_VARIABLE}';
+  window['env']['TEST_VARIABLE'] = '${TEST_VARIABLE}';
 })(this);


### PR DESCRIPTION
#### :tophat: What? Why?
This PR aims to solve the problem described here : https://github.com/mawoka-myblock/ClassQuiz/issues/544#issuecomment-4319983084

Frontend is now shipped with a way to use runtime-define environment variables.
This system rely on `env.template.js` file that define every value that we want to declare at runtime.

In Dockerfile the addition of envsubst allow to update variables on startup by writting env.js file based on template.

If you define a variable in runtime before the container build (with CLI or in the docker-compose file), and that you add the variable into `env.template.js` file (check the implementation of TEST_VARIABLE for syntax), you will be able to load it in frontend.

This PR also implement a wrapper to make the usage more developper-friendly as the reference for these variables is different between frontend and backend.
In frontend file just import wrapper and use it to get the env var you want :

```ts
import { runtimeEnvVarHandler } from '$lib/runtime/env.ts';

console.log(runtimeEnvVarHandler.get('TEST_VARIABLE'));
```

There is still a work to do and syntax can change but this is a first step to allow building docker images into the pipeline.
This will probably require up to 2 PR after this one to do it properly.

If needed I suggest to add some documentation on this system to make sure this is easily understandable for new comers.

#### :pushpin: Related Issues
- Related to #544 

#### Testing
- Add a console log in a frontend file to get the value of "TEST_VARIABLE"
```ts
import { runtimeEnvVarHandler } from '$lib/runtime/env.ts';

...

console.log(runtimeEnvVarHandler.get('TEST_VARIABLE'));
```

- Define value in docker-compose file
```
services:
  frontend:
    ...
    environment:
      ...
      TEST_VARIABLE: "HelloWorld2"
```
- Start everything and verify the console log in the console of the browser and the log in the container are correct

#### :clipboard: Checklist
- [ ] :question: ~~**CONSIDER** adding a unit test if your PR resolves an issue.~~
- [x] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [x] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [x] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: ~~**DO** make sure tests pass.~~
- [ ] :heavy_check_mark: ~~**DO** add CHANGELOG upgrade notes if required.~~
- [ ] :x:~~**AVOID** breaking the continuous integration build.~~
- [x] :x:**AVOID** making significant changes to the overall architecture.
